### PR TITLE
add genext to pyproject scripts & load preset from defaults

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ classifiers = [
 
 [project.scripts]
 genapp = "pymodaq_plugins_teaching.app.gen_app:main"
+genext = "pymodaq_plugins_teaching.extensions.gen_ext:main"
 
 [build-system]
 requires = [

--- a/src/pymodaq_plugins_teaching/extensions/gen_ext.py
+++ b/src/pymodaq_plugins_teaching/extensions/gen_ext.py
@@ -101,7 +101,7 @@ def main():
 
     app = mkQApp('GenExt')
 
-    preset_file_name = plugin_config('preset')
+    preset_file_name = plugin_config('defaults', 'preset')
     dashboard, extension, win = load_dashboard_with_preset(preset_file_name, EXTENSION_NAME)
     app.exec()
 


### PR DESCRIPTION
Not sure the preset was put in defaults for everyone but after trying to launch the gen_ext it failed because of it.